### PR TITLE
Schedule monthly video scans and persist last run state

### DIFF
--- a/channel_fetcher.py
+++ b/channel_fetcher.py
@@ -1,0 +1,20 @@
+import logging
+from datetime import datetime
+from typing import List
+
+logger = logging.getLogger(__name__)
+
+
+def fetch_new_videos(channel_id: str, last_run: datetime | None = None) -> List[str]:
+    """Fetch videos uploaded after ``last_run``.
+
+    This function is a placeholder for the actual implementation that would
+    interact with the YouTube API or another data source.
+    """
+    if last_run:
+        logger.info("Fetching videos for %s since %s", channel_id, last_run.isoformat())
+    else:
+        logger.info("Fetching all available videos for %s", channel_id)
+
+    # Placeholder return; in a real implementation this would contain new video IDs.
+    return []

--- a/scheduler.py
+++ b/scheduler.py
@@ -1,0 +1,47 @@
+import logging
+import time
+from datetime import datetime
+
+from apscheduler.schedulers.background import BackgroundScheduler
+
+import channel_fetcher
+import storage
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+# List of YouTube channel IDs to scan
+CHANNELS = []  # Populate with real channel IDs
+
+
+def run_channel_scan() -> None:
+    """Invoke the fetcher for each configured channel."""
+    logger.info("Executing scheduled channel scan")
+    for channel_id in CHANNELS:
+        last_run = storage.get_last_run(channel_id)
+        try:
+            channel_fetcher.fetch_new_videos(channel_id, last_run)
+            storage.update_last_run(channel_id, datetime.utcnow())
+            logger.info("Completed fetch for %s", channel_id)
+        except Exception as exc:  # pragma: no cover - logging only
+            logger.error("Failed to fetch videos for %s: %s", channel_id, exc)
+
+
+def start() -> BackgroundScheduler:
+    """Start the scheduler with a monthly job."""
+    scheduler = BackgroundScheduler()
+    # Run on the first day of each month at midnight
+    scheduler.add_job(run_channel_scan, "cron", day=1, hour=0, minute=0)
+    scheduler.start()
+    logger.info("Scheduler started with monthly job")
+    return scheduler
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution only
+    sched = start()
+    try:
+        while True:
+            time.sleep(1)
+    except (KeyboardInterrupt, SystemExit):
+        sched.shutdown()
+        logger.info("Scheduler stopped")

--- a/storage.py
+++ b/storage.py
@@ -1,0 +1,44 @@
+import json
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Optional
+
+# File used to persist last run timestamps per channel
+_STORAGE_FILE = Path("last_run.json")
+
+
+def _load_data() -> Dict[str, datetime]:
+    """Load persisted timestamps from disk."""
+    if _STORAGE_FILE.exists():
+        try:
+            with _STORAGE_FILE.open("r", encoding="utf-8") as fh:
+                data = json.load(fh)
+            return {key: datetime.fromisoformat(value) for key, value in data.items()}
+        except Exception as exc:  # pragma: no cover - logging only
+            logging.error("Failed to load last run timestamps: %s", exc)
+    return {}
+
+
+def _save_data(data: Dict[str, datetime]) -> None:
+    """Persist timestamps to disk."""
+    serialised = {key: value.isoformat() for key, value in data.items()}
+    try:
+        with _STORAGE_FILE.open("w", encoding="utf-8") as fh:
+            json.dump(serialised, fh)
+        logging.info("Persisted last run timestamps")
+    except Exception as exc:  # pragma: no cover - logging only
+        logging.error("Failed to persist last run timestamps: %s", exc)
+
+
+def get_last_run(channel_id: str) -> Optional[datetime]:
+    """Return the last run timestamp for the provided channel."""
+    data = _load_data()
+    return data.get(channel_id)
+
+
+def update_last_run(channel_id: str, timestamp: datetime) -> None:
+    """Update the last run timestamp for the provided channel."""
+    data = _load_data()
+    data[channel_id] = timestamp
+    _save_data(data)


### PR DESCRIPTION
## Summary
- add placeholder channel fetcher that respects last-run timestamp
- persist per-channel last run timestamps in JSON storage
- schedule monthly fetch job with APScheduler and basic logging

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c085be99ac8323b6e730c6ee893d2d