### PR TITLE
Add core data models with JSON/CSV serialization

### DIFF
--- a/docs/data_model.md
+++ b/docs/data_model.md
@@ -1,0 +1,49 @@
+# Data Model
+
+This project uses a small set of dataclasses to describe YouTube content and
+how it is processed.  All classes live in
+`src/youtube_scanner/models.py` and share a common design:
+
+* **JSON serialisation** – the `to_json()` and `from_json()` helpers convert
+  instances to and from JSON strings using the standard library.
+* **CSV serialisation** – the `csv_headers()` and `to_csv_row()` helpers make
+  it easy to write collections of instances to CSV files.  The
+  corresponding `from_csv_row()` constructors reverse the process.
+
+## `VideoMetadata`
+
+Describes basic information about a video.
+
+| field | type | description |
+| --- | --- | --- |
+| `video_id` | `str` | Unique identifier for the video. |
+| `title` | `str` | Video title. |
+| `description` | `str` | Description text. |
+| `publish_date` | `datetime` \| `None` | Time the video was published. |
+| `view_count` | `int` \| `None` | Number of views. |
+| `like_count` | `int` \| `None` | Number of likes. |
+| `comment_count` | `int` \| `None` | Number of comments. |
+| `duration` | `int` \| `None` | Length of the video in seconds. |
+| `is_short` | `bool` | Flag indicating if this video is a YouTube Short. |
+
+## `ShortMapping`
+
+Represents a link between a Short and its corresponding long-form video.
+
+| field | type | description |
+| --- | --- | --- |
+| `short_video_id` | `str` | Identifier of the short video. |
+| `full_video_id` | `str` \| `None` | Identifier of the long-form video. |
+| `relation_source` | `str` \| `None` | How the mapping was determined. |
+
+## `ChannelConfig`
+
+Defines configuration values for scanning a YouTube channel.
+
+| field | type | description |
+| --- | --- | --- |
+| `channel_id` | `str` | The channel's unique identifier. |
+| `name` | `str` | Human readable channel name. |
+| `category` | `str` \| `None` | Optional categorisation for the channel. |
+| `short_view_threshold` | `int` | Minimum views for a Short to be included. |
+| `top_n_shorts` | `int` | Number of top Shorts to retain per channel. |

--- a/src/youtube_scanner/models.py
+++ b/src/youtube_scanner/models.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+"""Data models for the Youtube Scanner project.
+
+This module defines lightweight data containers used throughout the
+application.  Each dataclass provides helpers for serialising to and from
+common formats such as dictionaries, JSON strings and CSV rows.
+"""
+
+from dataclasses import dataclass, asdict
+from datetime import datetime
+from typing import Any, Dict, Optional
+import json
+
+
+@dataclass
+class VideoMetadata:
+    """Metadata about a YouTube video.
+
+    Attributes:
+        video_id: Unique identifier for the video.
+        title: Video title.
+        description: Textual description of the video.
+        publish_date: When the video was published.
+        view_count: Number of views the video has received.
+        like_count: Number of likes for the video.
+        comment_count: Number of comments on the video.
+        duration: Length of the video in seconds.
+        is_short: True if the video is considered a YouTube Short.
+    """
+
+    video_id: str
+    title: str
+    description: str = ""
+    publish_date: Optional[datetime] = None
+    view_count: Optional[int] = None
+    like_count: Optional[int] = None
+    comment_count: Optional[int] = None
+    duration: Optional[int] = None
+    is_short: bool = False
+
+    # ------------------------------------------------------------------
+    # Serialisation helpers
+    # ------------------------------------------------------------------
+    def to_dict(self) -> Dict[str, Any]:
+        data = asdict(self)
+        if self.publish_date is not None:
+            data["publish_date"] = self.publish_date.isoformat()
+        return data
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict())
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "VideoMetadata":
+        data = dict(data)
+        publish_date = data.get("publish_date")
+        if publish_date is not None and not isinstance(publish_date, datetime):
+            data["publish_date"] = datetime.fromisoformat(publish_date)
+        return cls(**data)
+
+    @classmethod
+    def from_json(cls, raw: str) -> "VideoMetadata":
+        return cls.from_dict(json.loads(raw))
+
+    # CSV helpers -------------------------------------------------------
+    @classmethod
+    def csv_headers(cls) -> list[str]:
+        return [
+            "video_id",
+            "title",
+            "description",
+            "publish_date",
+            "view_count",
+            "like_count",
+            "comment_count",
+            "duration",
+            "is_short",
+        ]
+
+    def to_csv_row(self) -> list[str]:
+        data = self.to_dict()
+        return ["" if data.get(h) is None else str(data.get(h)) for h in self.csv_headers()]
+
+    @classmethod
+    def from_csv_row(cls, row: Dict[str, str]) -> "VideoMetadata":
+        data: Dict[str, Any] = dict(row)
+        if data.get("publish_date"):
+            data["publish_date"] = datetime.fromisoformat(data["publish_date"])
+        for key in ["view_count", "like_count", "comment_count", "duration"]:
+            if data.get(key):
+                data[key] = int(data[key])
+        if data.get("is_short"):
+            data["is_short"] = data["is_short"].lower() in {"1", "true", "yes"}
+        return cls(**data)
+
+
+@dataclass
+class ShortMapping:
+    """Links a Short to its long-form video counterpart."""
+
+    short_video_id: str
+    full_video_id: Optional[str] = None
+    relation_source: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict())
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ShortMapping":
+        return cls(**data)
+
+    @classmethod
+    def from_json(cls, raw: str) -> "ShortMapping":
+        return cls.from_dict(json.loads(raw))
+
+    @classmethod
+    def csv_headers(cls) -> list[str]:
+        return ["short_video_id", "full_video_id", "relation_source"]
+
+    def to_csv_row(self) -> list[str]:
+        data = self.to_dict()
+        return ["" if data.get(h) is None else str(data.get(h)) for h in self.csv_headers()]
+
+    @classmethod
+    def from_csv_row(cls, row: Dict[str, str]) -> "ShortMapping":
+        return cls(**row)
+
+
+@dataclass
+class ChannelConfig:
+    """Configuration describing a YouTube channel to scan."""
+
+    channel_id: str
+    name: str
+    category: Optional[str] = None
+    short_view_threshold: int = 50_000
+    top_n_shorts: int = 20
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict())
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ChannelConfig":
+        return cls(**data)
+
+    @classmethod
+    def from_json(cls, raw: str) -> "ChannelConfig":
+        return cls.from_dict(json.loads(raw))
+
+    @classmethod
+    def csv_headers(cls) -> list[str]:
+        return [
+            "channel_id",
+            "name",
+            "category",
+            "short_view_threshold",
+            "top_n_shorts",
+        ]
+
+    def to_csv_row(self) -> list[str]:
+        data = self.to_dict()
+        return ["" if data.get(h) is None else str(data.get(h)) for h in self.csv_headers()]
+
+    @classmethod
+    def from_csv_row(cls, row: Dict[str, str]) -> "ChannelConfig":
+        data: Dict[str, Any] = dict(row)
+        if data.get("short_view_threshold"):
+            data["short_view_threshold"] = int(data["short_view_threshold"])
+        if data.get("top_n_shorts"):
+            data["top_n_shorts"] = int(data["top_n_shorts"])
+        return cls(**data)


### PR DESCRIPTION
## Summary
- add VideoMetadata, ShortMapping and ChannelConfig dataclasses
- implement JSON and CSV serialisation helpers
- document the data model schema

## Testing
- `python -m py_compile src/youtube_scanner/models.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c085b9253c83238c2aee0e5ff5994c