### PR TITLE
chore: add CLAUDE guidelines and pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.12.1
+    hooks:
+      - id: black
+        args: ["--line-length=88"]
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.1.0
+    hooks:
+      - id: flake8
+  - repo: https://github.com/pre-commit/mirrors-isort
+    rev: v5.9.3
+    hooks:
+      - id: isort
+        args: ["--profile", "black"]
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.8.0
+    hooks:
+      - id: mypy
+        additional_dependencies: [types-requests]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,33 @@
+# CLAUDE Guidelines
+
+## Directory Whitelist
+The repository should only contain the following top-level directories:
+
+- `src/`
+- `tests/`
+- `docs/`
+- `.github/`
+- `scripts/`
+
+Files or directories outside this whitelist should be removed or relocated into an allowed directory.
+
+## Code Style
+- Format Python code with [Black](https://github.com/psf/black).
+- Sort imports with [isort](https://pycqa.github.io/isort/).
+- Lint using [Flake8](https://flake8.pycqa.org/).
+- Type-check with [mypy](http://mypy-lang.org/).
+- Follow PEP 8 naming conventions:
+  - Functions and variables: `snake_case`
+  - Classes: `PascalCase`
+  - Constants: `UPPER_SNAKE_CASE`
+
+## Commit Message Format
+Use [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>(<scope>): <short summary>
+```
+
+Examples of `type` include `feat`, `fix`, `docs`, `style`, `refactor`, `test`, and `chore`.
+
+Run `pre-commit run --all-files` before committing to ensure style and type checks pass.


### PR DESCRIPTION
## Summary
- define repository structure, style, and commit conventions in `CLAUDE.md`
- add `.pre-commit-config.yaml` running black, flake8, isort, and mypy

## Testing
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68c085b557748323929531ef529528c8