### PR TITLE
Add logging configuration and usage conventions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+app.log

--- a/loggers.md
+++ b/loggers.md
@@ -1,0 +1,13 @@
+# Logging Conventions
+
+- Each module defines a module-level logger using `logging.getLogger(__name__)`.
+- The root logger is configured in `main.py` via `logging.config.dictConfig`.
+- Console output logs messages at `INFO` level and above.
+- Debug information is written to `app.log` using the same formatter, which includes:
+  - timestamp
+  - module name
+  - log level
+  - log message
+- Wrap external API calls and subprocesses in `try/except` blocks.
+  - Log recoverable issues with `logger.warning`.
+  - Log failures that abort processing with `logger.error` and re-raise when needed.

--- a/main.py
+++ b/main.py
@@ -1,0 +1,48 @@
+import logging
+import logging.config
+from youtube_api import fetch_video_data
+from process_utils import run_command
+
+LOGGING_CONFIG = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'formatters': {
+        'standard': {
+            'format': '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+        },
+    },
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+            'level': 'INFO',
+            'formatter': 'standard',
+            'stream': 'ext://sys.stdout'
+        },
+        'file': {
+            'class': 'logging.FileHandler',
+            'level': 'DEBUG',
+            'formatter': 'standard',
+            'filename': 'app.log',
+            'encoding': 'utf8'
+        },
+    },
+    'root': {
+        'level': 'DEBUG',
+        'handlers': ['console', 'file']
+    }
+}
+
+def main():
+    logging.config.dictConfig(LOGGING_CONFIG)
+    try:
+        fetch_video_data('dQw4w9WgXcQ', 'INVALID_API_KEY')
+    except Exception:
+        pass
+
+    try:
+        run_command(['echo', 'Hello'])
+    except Exception:
+        pass
+
+if __name__ == '__main__':
+    main()

--- a/process_utils.py
+++ b/process_utils.py
@@ -1,0 +1,18 @@
+import logging
+import subprocess
+from typing import List
+
+logger = logging.getLogger(__name__)
+
+
+def run_command(cmd: List[str]) -> str:
+    """Run an external command and return its output."""
+    try:
+        result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+        return result.stdout
+    except FileNotFoundError as exc:
+        logger.warning("Command not found: %s", exc)
+        return ""
+    except subprocess.CalledProcessError as exc:
+        logger.error("Command '%s' failed with %s", " ".join(cmd), exc)
+        raise

--- a/youtube_api.py
+++ b/youtube_api.py
@@ -1,0 +1,31 @@
+import logging
+from typing import Any, Dict
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+def fetch_video_data(video_id: str, api_key: str) -> Dict[str, Any]:
+    """Fetch video metadata from the YouTube Data API."""
+    url = 'https://www.googleapis.com/youtube/v3/videos'
+    params = {
+        'part': 'snippet,contentDetails,statistics',
+        'id': video_id,
+        'key': api_key,
+    }
+    try:
+        response = requests.get(url, params=params, timeout=10)
+        response.raise_for_status()
+    except requests.exceptions.HTTPError as exc:
+        logger.error("YouTube API returned an error for %s: %s", video_id, exc)
+        raise
+    except requests.exceptions.RequestException as exc:
+        logger.warning("Network issue when fetching %s: %s", video_id, exc)
+        return {}
+
+    try:
+        return response.json()
+    except ValueError as exc:
+        logger.warning("Invalid JSON for %s: %s", video_id, exc)
+        return {}


### PR DESCRIPTION
## Summary
- Configure root logger with console and file handlers using `logging.config.dictConfig`
- Add module-level loggers and wrap API/subprocess calls with structured error handling
- Document logging approach in `loggers.md`

## Testing
- `python -m py_compile main.py youtube_api.py process_utils.py`
- `python main.py`


------
https://chatgpt.com/codex/tasks/task_e_68c085b44508832388a66fd2ae4ce843