### PR TITLE
Implement YouTube uploads playlist retrieval

### DIFF
--- a/tests/test_youtube_api.py
+++ b/tests/test_youtube_api.py
@@ -1,0 +1,56 @@
+import requests
+from unittest.mock import Mock, patch
+
+from youtube_api import fetch_uploads_playlist_video_ids
+
+
+def test_fetch_uploads_playlist_video_ids_handles_pagination():
+    channel_resp = Mock()
+    channel_resp.json.return_value = {
+        "items": [{"contentDetails": {"relatedPlaylists": {"uploads": "UPLOADS_ID"}}}]
+    }
+    channel_resp.raise_for_status.return_value = None
+
+    first_page = Mock()
+    first_page.json.return_value = {
+        "items": [
+            {"contentDetails": {"videoId": "id1"}},
+            {"contentDetails": {"videoId": "id2"}},
+        ],
+        "nextPageToken": "TOKEN",
+    }
+    first_page.raise_for_status.return_value = None
+
+    second_page = Mock()
+    second_page.json.return_value = {
+        "items": [{"contentDetails": {"videoId": "id3"}}]
+    }
+    second_page.raise_for_status.return_value = None
+
+    with patch("youtube_api.requests.get", side_effect=[channel_resp, first_page, second_page]):
+        result = fetch_uploads_playlist_video_ids("CHANNEL", "KEY")
+
+    assert result == ["id1", "id2", "id3"]
+
+
+def test_fetch_uploads_playlist_video_ids_quota_exceeded(caplog):
+    resp = Mock()
+    resp.status_code = 403
+    resp.json.return_value = {"error": {"errors": [{"reason": "quotaExceeded"}]}}
+    resp.raise_for_status.side_effect = requests.exceptions.HTTPError(response=resp)
+
+    with patch("youtube_api.requests.get", return_value=resp):
+        with caplog.at_level("ERROR"):
+            result = fetch_uploads_playlist_video_ids("CHANNEL", "KEY")
+
+    assert result == []
+    assert "quota exceeded" in caplog.text.lower()
+
+
+def test_fetch_uploads_playlist_video_ids_network_issue(caplog):
+    with patch("youtube_api.requests.get", side_effect=requests.exceptions.RequestException("boom")):
+        with caplog.at_level("WARNING"):
+            result = fetch_uploads_playlist_video_ids("CHANNEL", "KEY")
+
+    assert result == []
+    assert "network issue" in caplog.text.lower()

--- a/youtube_api.py
+++ b/youtube_api.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 import requests
 
@@ -29,3 +29,81 @@ def fetch_video_data(video_id: str, api_key: str) -> Dict[str, Any]:
     except ValueError as exc:
         logger.warning("Invalid JSON for %s: %s", video_id, exc)
         return {}
+
+
+def fetch_uploads_playlist_video_ids(channel_id: str, api_key: str) -> List[str]:
+    """Return all video IDs from a channel's uploads playlist.
+
+    This function looks up the channel's ``uploads`` playlist and iterates
+    through all items using pagination. It handles quota errors from the
+    YouTube Data API and transient network issues, returning the list of
+    video IDs fetched so far when an error occurs.
+    """
+    channel_url = "https://www.googleapis.com/youtube/v3/channels"
+    channel_params = {"part": "contentDetails", "id": channel_id, "key": api_key}
+    try:
+        response = requests.get(channel_url, params=channel_params, timeout=10)
+        response.raise_for_status()
+    except requests.exceptions.HTTPError as exc:
+        try:
+            error_reason = response.json()["error"]["errors"][0].get("reason")
+        except Exception:  # pragma: no cover - malformed error payload
+            error_reason = None
+        if response.status_code == 403 and error_reason == "quotaExceeded":
+            logger.error("YouTube API quota exceeded when fetching uploads playlist for %s", channel_id)
+            return []
+        logger.error("YouTube API returned an error for %s: %s", channel_id, exc)
+        raise
+    except requests.exceptions.RequestException as exc:
+        logger.warning("Network issue when fetching uploads playlist for %s: %s", channel_id, exc)
+        return []
+
+    uploads_playlist_id = (
+        response.json()
+        .get("items", [{}])[0]
+        .get("contentDetails", {})
+        .get("relatedPlaylists", {})
+        .get("uploads")
+    )
+    if not uploads_playlist_id:
+        logger.warning("No uploads playlist found for %s", channel_id)
+        return []
+
+    video_ids: List[str] = []
+    playlist_url = "https://www.googleapis.com/youtube/v3/playlistItems"
+    params = {
+        "part": "contentDetails",
+        "playlistId": uploads_playlist_id,
+        "maxResults": 50,
+        "key": api_key,
+    }
+    while True:
+        try:
+            pl_response = requests.get(playlist_url, params=params, timeout=10)
+            pl_response.raise_for_status()
+        except requests.exceptions.HTTPError as exc:
+            try:
+                error_reason = pl_response.json()["error"]["errors"][0].get("reason")
+            except Exception:  # pragma: no cover - malformed error payload
+                error_reason = None
+            if pl_response.status_code == 403 and error_reason == "quotaExceeded":
+                logger.error("YouTube API quota exceeded when fetching videos for %s", channel_id)
+                return video_ids
+            logger.error("YouTube API returned an error for %s: %s", channel_id, exc)
+            raise
+        except requests.exceptions.RequestException as exc:
+            logger.warning("Network issue when fetching playlist items for %s: %s", channel_id, exc)
+            return video_ids
+
+        data = pl_response.json()
+        for item in data.get("items", []):
+            vid = item.get("contentDetails", {}).get("videoId")
+            if vid:
+                video_ids.append(vid)
+
+        next_token = data.get("nextPageToken")
+        if not next_token:
+            break
+        params["pageToken"] = next_token
+
+    return video_ids


### PR DESCRIPTION
## Summary
- add `fetch_uploads_playlist_video_ids` to fetch all videos from a channel's uploads playlist with pagination
- handle API quota and network errors
- add tests for pagination and error conditions

## Testing
- `pip install requests >/tmp/pip.log && tail -n 20 /tmp/pip.log`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c09a3b58e48323bead3e9cfab753b7