### PR TITLE
Implement short-to-long mapping and channel fetcher

### DIFF
--- a/src/youtube_scanner/channel_fetcher.py
+++ b/src/youtube_scanner/channel_fetcher.py
@@ -1,8 +1,10 @@
 """Fetch uploads using the YouTube Data API."""
 
-from typing import List
+from typing import Dict, List, Any
 import logging
 from logging.handlers import RotatingFileHandler
+
+import requests
 
 logger = logging.getLogger(__name__)
 if not logger.handlers:
@@ -12,8 +14,38 @@ if not logger.handlers:
     logger.addHandler(handler)
 logger.setLevel(logging.INFO)
 
+API_URL = "https://www.googleapis.com/youtube/v3/search"
+
+
+def fetch_channel_videos(api_key: str, channel_id: str) -> Dict[str, Any]:
+    """Fetch videos for a channel using the YouTube Data API.
+
+    Parameters
+    ----------
+    api_key:
+        API key used for authenticating with the YouTube Data API.
+    channel_id:
+        Identifier of the YouTube channel whose videos should be fetched.
+
+    Returns
+    -------
+    dict
+        JSON response from the API containing video information.
+    """
+    logger.info("Fetching channel videos for %s", channel_id)
+    params = {
+        "part": "snippet",
+        "channelId": channel_id,
+        "maxResults": 50,
+        "order": "date",
+        "key": api_key,
+    }
+    response = requests.get(API_URL, params=params, timeout=10)
+    response.raise_for_status()
+    return response.json()
+
+
 def fetch_uploads(channel_id: str) -> List[str]:
-    """Placeholder for fetching upload video IDs from a channel."""
+    """Placeholder retained for backward compatibility."""
     logger.info("Fetching uploads for channel %s", channel_id)
-    # TODO: Implement YouTube Data API calls here
     return []

--- a/src/youtube_scanner/short_mapper.py
+++ b/src/youtube_scanner/short_mapper.py
@@ -1,0 +1,86 @@
+"""Utilities for linking YouTube Shorts to their source videos."""
+
+from __future__ import annotations
+
+import logging
+import re
+from logging.handlers import RotatingFileHandler
+from typing import Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+if not logger.handlers:
+    handler = RotatingFileHandler("youtube_scanner.log", maxBytes=1_000_000, backupCount=3)
+    formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+logger.setLevel(logging.INFO)
+
+# Regex to capture YouTube video IDs from typical URL formats
+YOUTUBE_URL_RE = re.compile(
+    r"(?:https?://)?(?:www\.)?youtu(?:\.be/|be\.com/watch\?v=)([\w-]{11})"
+)
+
+
+def _extract_video_id(text: str) -> Optional[str]:
+    """Extract a YouTube video ID from *text* if present."""
+    match = YOUTUBE_URL_RE.search(text or "")
+    return match.group(1) if match else None
+
+
+def map_short_to_long(
+    short: Dict[str, str],
+    videos: List[Dict[str, str]],
+    *,
+    return_source: bool = False,
+) -> Optional[Dict[str, str] | Tuple[Dict[str, str], str]]:
+    """Map a single short video to a full-length video.
+
+    Parameters
+    ----------
+    short:
+        Metadata for the short (expects ``id`` and ``title`` keys, optionally
+        ``description``, ``pinned_comment`` and ``transcript``).
+    videos:
+        Iterable of candidate full-length video metadata dictionaries. Each
+        dictionary should contain at least ``id`` and ``title`` keys and may
+        include ``transcript``.
+    return_source:
+        When ``True`` the function returns a tuple ``(video, source)`` where
+        ``source`` indicates how the match was made. When ``False`` only the
+        video dictionary is returned.
+    """
+
+    logger.info("Mapping short %s", short.get("id"))
+
+    # 1. Direct link in description
+    video_id = _extract_video_id(short.get("description", ""))
+    if video_id:
+        for video in videos:
+            if video.get("id") == video_id:
+                return (video, "description") if return_source else video
+
+    # 2. Direct link in pinned comment
+    video_id = _extract_video_id(short.get("pinned_comment", ""))
+    if video_id:
+        for video in videos:
+            if video.get("id") == video_id:
+                return (video, "pinned_comment") if return_source else video
+
+    # 3. Keyword search on titles
+    short_title = (short.get("title") or "").lower()
+    for video in videos:
+        if (video.get("title") or "").lower() == short_title:
+            return (video, "title") if return_source else video
+    for video in videos:
+        if short_title and short_title in (video.get("title") or "").lower():
+            return (video, "title") if return_source else video
+
+    # 4. Transcript search
+    short_transcript = (short.get("transcript") or "").strip().lower()
+    if short_transcript:
+        for video in videos:
+            transcript = (video.get("transcript") or "").lower()
+            if short_transcript in transcript:
+                return (video, "transcript") if return_source else video
+
+    return (None if return_source else None)

--- a/src/youtube_scanner/shorts_mapper.py
+++ b/src/youtube_scanner/shorts_mapper.py
@@ -4,6 +4,8 @@ from typing import Dict, List
 import logging
 from logging.handlers import RotatingFileHandler
 
+from .short_mapper import map_short_to_long
+
 logger = logging.getLogger(__name__)
 if not logger.handlers:
     handler = RotatingFileHandler("youtube_scanner.log", maxBytes=1_000_000, backupCount=3)
@@ -12,8 +14,33 @@ if not logger.handlers:
     logger.addHandler(handler)
 logger.setLevel(logging.INFO)
 
-def map_shorts_to_full(shorts: List[str], full_videos: List[str]) -> Dict[str, str]:
-    """Placeholder for mapping shorts to full videos."""
+
+def map_shorts_to_full(
+    shorts: List[Dict[str, str]],
+    full_videos: List[Dict[str, str]],
+) -> Dict[str, Dict[str, str]]:
+    """Map a list of shorts to their corresponding full videos.
+
+    Parameters
+    ----------
+    shorts:
+        List of short video metadata dictionaries. Each dictionary should at
+        minimum contain an ``id`` key and may include ``title``, ``description``,
+        ``pinned_comment`` and ``transcript``.
+    full_videos:
+        List of candidate full-length video metadata dictionaries.
+
+    Returns
+    -------
+    dict
+        Mapping of short IDs to dictionaries containing the matched full video
+        ID and the relation ``source`` that triggered the match.
+    """
     logger.info("Mapping %d shorts to full videos", len(shorts))
-    # TODO: Implement mapping logic using description, comments, search, and transcripts
-    return {}
+    mapping: Dict[str, Dict[str, str]] = {}
+    for short in shorts:
+        result = map_short_to_long(short, full_videos, return_source=True)
+        if result:
+            video, source = result
+            mapping[short["id"]] = {"video_id": video["id"], "source": source}
+    return mapping


### PR DESCRIPTION
## Summary
- Map YouTube Shorts to full videos using description links, pinned comments, title keywords, and transcript search
- Support batch mapping with relation source data
- Fetch channel videos from YouTube Data API via requests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c09a404dd083239c171e88ee488e22